### PR TITLE
Simplify and optimize Intersect and Subtract

### DIFF
--- a/set.go
+++ b/set.go
@@ -88,23 +88,10 @@ func (s Set) Subtract(other Set) {
 // Intersect causes the receiver Set to only contain elements also found in the
 // other Set argument.
 func (s Set) Intersect(other Set) {
-	intersect := New()
-
-	for item := range other {
-		if s.Has(item) {
-			intersect.Insert(item)
-		}
-	}
-
-	var remove []string
 	for item := range s {
-		if !intersect.Has(item) {
-			remove = append(remove, item)
+		if !other.Has(item) {
+			s.Remove(item)
 		}
-	}
-
-	for _, r := range remove {
-		s.Remove(r)
 	}
 }
 

--- a/set.go
+++ b/set.go
@@ -89,8 +89,9 @@ func (s Set) Subtract(other Set) {
 // other Set argument.
 func (s Set) Intersect(other Set) {
 	for item := range s {
-		if !other.Has(item) {
-			s.Remove(item)
+		e := strings.ToLower(item)
+		if _, exists := other[e]; !exists {
+			delete(s, e)
 		}
 	}
 }

--- a/set.go
+++ b/set.go
@@ -81,9 +81,7 @@ func (s Set) Len() int {
 // Subtract removes all elements in the other Set argument from the receiver Set.
 func (s Set) Subtract(other Set) {
 	for item := range other {
-		if s.Has(item) {
-			s.Remove(item)
-		}
+		s.Remove(item)
 	}
 }
 


### PR DESCRIPTION
Hey Jeff! I see that this project is used in Amass, so I decided to take a look and I noticed some minor areas for improvement:

* No need to test for membership in `Subtract`;
* `Intersect` can be simplified quite a bit, as well as optimized (in order to remove one call to `strings.ToLower`).

Incidentally, I also noticed `Set`'s `String` method isn't covered by the tests.;`TestString` doesn't actually rely on `String` at all.  I can push a fix for that as well, if you think that's appropriate as part of the same PR.